### PR TITLE
Ability to ship and update card subnets

### DIFF
--- a/lib/synapse_pay_rest/api/subnets.rb
+++ b/lib/synapse_pay_rest/api/subnets.rb
@@ -76,11 +76,22 @@ module SynapsePayRest
       client.patch(path, payload)
     end
 
+    def ship(user_id:, node_id:, subnet_id:, payload:)
+      path = ship_card_path(user_id: user_id, node_id: node_id, subnet_id: subnet_id)
+      client.patch(path, payload)
+    end
+
     private
 
     def create_subnet_path(user_id:, node_id:, subnet_id: nil)
       path = "/users/#{user_id}/nodes/#{node_id}/subnets"
       path += "/#{subnet_id}" if subnet_id
+      path
+    end
+
+    def ship_card_path(user_id:, node_id:, subnet_id: nil)
+      path = create_subnet_path(user_id: user_id, node_id: node_id, subnet_id: subnet_id)
+      path += "/ship"
       path
     end
   end

--- a/lib/synapse_pay_rest/models/subnet/subnet.rb
+++ b/lib/synapse_pay_rest/models/subnet/subnet.rb
@@ -274,16 +274,18 @@ module SynapsePayRest
       payload['card_pin']     = options[:card_pin] if options[:card_pin]
       payload['status']       = options[:status] if options[:status]
 
-      if options[:preferences][:allow_foreign_transactions]
-        payload['preferences']['allow_foreign_transactions']  = options[:preferences][:allow_foreign_transactions]
-      end
+      if options[:preferences]
+        if options[:preferences][:allow_foreign_transactions]
+          payload['preferences']['allow_foreign_transactions']  = options[:preferences][:allow_foreign_transactions]
+        end
 
-      if options[:preferences][:daily_atm_withdrawal_limit]
-        payload['preferences']['daily_atm_withdrawal_limit']  = options[:preferences][:daily_atm_withdrawal_limit]
-      end
+        if options[:preferences][:daily_atm_withdrawal_limit]
+          payload['preferences']['daily_atm_withdrawal_limit']  = options[:preferences][:daily_atm_withdrawal_limit]
+        end
 
-      if options[:preferences][:daily_transaction_limit]
-        payload['preferences']['daily_transaction_limit']  = options[:preferences][:daily_transaction_limit]
+        if options[:preferences][:daily_transaction_limit]
+          payload['preferences']['daily_transaction_limit']  = options[:preferences][:daily_transaction_limit]
+        end
       end
 
       payload

--- a/lib/synapse_pay_rest/models/subnet/subnet.rb
+++ b/lib/synapse_pay_rest/models/subnet/subnet.rb
@@ -182,7 +182,11 @@ module SynapsePayRest
     # 
     # @raise [SynapsePayRest::Error]
     # 
-    # @return [Array<SynapsePayRest::Subnet>] (self)
+    # @return [Hash] {
+    #   node_id [String]
+    #   subnet_id [String]
+    #   transaction_id [String]
+    # }
     def ship_card(fee_node_id, cardholder_name, **options)
       payload = {
         'fee_node_id' => fee_node_id,

--- a/lib/synapse_pay_rest/models/subnet/subnet.rb
+++ b/lib/synapse_pay_rest/models/subnet/subnet.rb
@@ -204,13 +204,25 @@ module SynapsePayRest
         subnet_id: id,
         payload: payload
       )
-      if response['subnets']
-        # api v3.1
-        self.class.from_response(node, response['subnets'])
+
+      if response['error']
+        args = {
+          error: {
+            code:           response['error']['code'],
+            message:        response['error']['en'],
+            error_code:     response['error_code'],
+            http_code:      response['http_code']
+          }
+        }
       else
-        # api v3.1.1
-        self.class.from_response(node, response)
+        args = {
+          transaction_id:   response['transaction_id'],
+          node_id:          response['node_id'],
+          subnet_id:        response['subnet_id']
+        }
       end
+      
+      args
     end
 
     # Checks if two Subnet instances have same id (different instances of same record).

--- a/lib/synapse_pay_rest/models/subnet/subnet.rb
+++ b/lib/synapse_pay_rest/models/subnet/subnet.rb
@@ -265,13 +265,18 @@ module SynapsePayRest
     # @raise [SynapsePayRest::Error] if HTTP error or invalid argument format
     # 
     # @return [SynapsePayRest::Subnet] new instance corresponding to same API record
-    def update(**options)
+    def update(user_id:, node_id:, **options)
       if options.empty?
         raise ArgumentError, 'must provide a key-value pair to update. keys: card_pin,
           status, preferences[:allow_foreign_transactions],
           preferences[:daily_atm_withdrawal_limit], preferences[:daily_transaction_limit]'
       end
-      response = client.subnets.update(subnet_id: id, payload: payload_for_card_update(options))
+      response = client.subnets.update(
+        user_id: user_id,
+        node_id: node_id,
+        subnet_id: id,
+        payload: payload_for_card_update(options)
+      )
       # return an updated subnet instance
       self.class.from_response(client, response)
     end

--- a/lib/synapse_pay_rest/models/subnet/subnet.rb
+++ b/lib/synapse_pay_rest/models/subnet/subnet.rb
@@ -256,7 +256,7 @@ module SynapsePayRest
         payload: payload_for_card_update(options)
       )
       # return an updated subnet instance
-      self.class.from_response(client, response)
+      self.class.from_response(node, response)
     end
 
 

--- a/lib/synapse_pay_rest/models/subnet/subnet.rb
+++ b/lib/synapse_pay_rest/models/subnet/subnet.rb
@@ -231,7 +231,7 @@ module SynapsePayRest
 
     # Updates the given key value pairs.
     # 
-    # @param card_pin [String]
+    # @param pin [String]
     # @param status [String]
     # @param preferences [Hash]:
     #   {
@@ -244,11 +244,6 @@ module SynapsePayRest
     # 
     # @return [SynapsePayRest::Subnet] new instance corresponding to same API record
     def update(**options)
-      if options.empty?
-        raise ArgumentError, 'must provide a key-value pair to update. keys: card_pin,
-          status, preferences[:allow_foreign_transactions],
-          preferences[:daily_atm_withdrawal_limit], preferences[:daily_transaction_limit]'
-      end
       response = node.user.client.subnets.update(
         user_id: node.user.id,
         node_id: node.id,
@@ -271,20 +266,20 @@ module SynapsePayRest
     def payload_for_card_update(**options)
       payload = {}
       # must have one of these
-      payload['card_pin']     = options[:card_pin] if options[:card_pin]
-      payload['status']       = options[:status] if options[:status]
+      payload['pin']     = options[:pin] if options[:pin]
+      payload['status']  = options[:status] if options[:status]
+
+      unless payload['pin'] || payload['status']
+        raise ArgumentError, 'must provide a key-value pair to update. keys: pin,
+          status, preferences[:allow_foreign_transactions],
+          preferences[:daily_atm_withdrawal_limit], preferences[:daily_transaction_limit]'
+      end
 
       if options[:preferences]
-        if options[:preferences][:allow_foreign_transactions]
-          payload['preferences']['allow_foreign_transactions']  = options[:preferences][:allow_foreign_transactions]
-        end
+        payload['preferences'] = {}
 
-        if options[:preferences][:daily_atm_withdrawal_limit]
-          payload['preferences']['daily_atm_withdrawal_limit']  = options[:preferences][:daily_atm_withdrawal_limit]
-        end
-
-        if options[:preferences][:daily_transaction_limit]
-          payload['preferences']['daily_transaction_limit']  = options[:preferences][:daily_transaction_limit]
+        options[:preferences].each do |key ,value|
+          payload['preferences'][key.to_s] = value
         end
       end
 

--- a/lib/synapse_pay_rest/models/subnet/subnet.rb
+++ b/lib/synapse_pay_rest/models/subnet/subnet.rb
@@ -142,28 +142,6 @@ module SynapsePayRest
           exp:                response['exp']
         }
       end
-
-      # Converts #update args into API payload structure for CARD subnets.
-      def payload_for_card_update(**options)
-        payload = {}
-        # must have one of these
-        payload['card_pin']     = options[:card_pin] if options[:card_pin]
-        payload['status']       = options[:status] if options[:status]
-
-        if options[:preferences][:allow_foreign_transactions]
-          payload['preferences']['allow_foreign_transactions']  = options[:preferences][:allow_foreign_transactions]
-        end
-
-        if options[:preferences][:daily_atm_withdrawal_limit]
-          payload['preferences']['daily_atm_withdrawal_limit']  = options[:preferences][:daily_atm_withdrawal_limit]
-        end
-
-        if options[:preferences][:daily_transaction_limit]
-          payload['preferences']['daily_transaction_limit']  = options[:preferences][:daily_transaction_limit]
-        end
-
-        payload
-      end
     end
 
     # @note Do not call directly. Use Subnet.create or other class
@@ -275,7 +253,7 @@ module SynapsePayRest
         user_id: node.user.id,
         node_id: node.id,
         subnet_id: id,
-        payload: self.class.payload_for_card_update(options)
+        payload: payload_for_card_update(options)
       )
       # return an updated subnet instance
       self.class.from_response(client, response)
@@ -285,6 +263,30 @@ module SynapsePayRest
     # Checks if two Subnet instances have same id (different instances of same record).
     def ==(other)
       other.instance_of?(self.class) && !id.nil? && id == other.id
+    end
+
+    private
+
+    # Converts #update args into API payload structure for CARD subnets.
+    def payload_for_card_update(**options)
+      payload = {}
+      # must have one of these
+      payload['card_pin']     = options[:card_pin] if options[:card_pin]
+      payload['status']       = options[:status] if options[:status]
+
+      if options[:preferences][:allow_foreign_transactions]
+        payload['preferences']['allow_foreign_transactions']  = options[:preferences][:allow_foreign_transactions]
+      end
+
+      if options[:preferences][:daily_atm_withdrawal_limit]
+        payload['preferences']['daily_atm_withdrawal_limit']  = options[:preferences][:daily_atm_withdrawal_limit]
+      end
+
+      if options[:preferences][:daily_transaction_limit]
+        payload['preferences']['daily_transaction_limit']  = options[:preferences][:daily_transaction_limit]
+      end
+
+      payload
     end
   end
 end

--- a/lib/synapse_pay_rest/models/subnet/subnet.rb
+++ b/lib/synapse_pay_rest/models/subnet/subnet.rb
@@ -275,7 +275,7 @@ module SynapsePayRest
         user_id: node.user.id,
         node_id: node.id,
         subnet_id: id,
-        payload: payload_for_card_update(options)
+        payload: self.class.payload_for_card_update(options)
       )
       # return an updated subnet instance
       self.class.from_response(client, response)

--- a/lib/synapse_pay_rest/models/subnet/subnet.rb
+++ b/lib/synapse_pay_rest/models/subnet/subnet.rb
@@ -271,7 +271,7 @@ module SynapsePayRest
           status, preferences[:allow_foreign_transactions],
           preferences[:daily_atm_withdrawal_limit], preferences[:daily_transaction_limit]'
       end
-      response = client.subnets.update(
+      response = node.user.client.subnets.update(
         user_id: node.user.id,
         node_id: node.id,
         subnet_id: id,

--- a/lib/synapse_pay_rest/models/subnet/subnet.rb
+++ b/lib/synapse_pay_rest/models/subnet/subnet.rb
@@ -265,15 +265,15 @@ module SynapsePayRest
     # @raise [SynapsePayRest::Error] if HTTP error or invalid argument format
     # 
     # @return [SynapsePayRest::Subnet] new instance corresponding to same API record
-    def update(user_id:, node_id:, **options)
+    def update(**options)
       if options.empty?
         raise ArgumentError, 'must provide a key-value pair to update. keys: card_pin,
           status, preferences[:allow_foreign_transactions],
           preferences[:daily_atm_withdrawal_limit], preferences[:daily_transaction_limit]'
       end
       response = client.subnets.update(
-        user_id: user_id,
-        node_id: node_id,
+        user_id: node.user.id,
+        node_id: node.id,
         subnet_id: id,
         payload: payload_for_card_update(options)
       )

--- a/lib/synapse_pay_rest/models/subnet/subnet.rb
+++ b/lib/synapse_pay_rest/models/subnet/subnet.rb
@@ -174,6 +174,45 @@ module SynapsePayRest
       end
     end
 
+    # Provisions a card
+    # 
+    # @param fee_node_id [String] Id of the Node to be charged for the fee
+    # @param cardholder_name [String] Name of the cardholder
+    # @param **options [Hash] Options to pass to Synapse's API
+    # 
+    # @raise [SynapsePayRest::Error]
+    # 
+    # @return [Array<SynapsePayRest::Subnet>] (self)
+    def ship_card(fee_node_id, cardholder_name, **options)
+      payload = {
+        'fee_node_id' => fee_node_id,
+        'cardholder_name' => cardholder_name,
+        'expedite' => false
+      }
+
+      if options['expedite'].present?
+        payload['expedite'] = options['expedite']
+      end
+
+      if options['card_style_id'].present?
+        payload['card_style_id'] = options['card_style_id']
+      end
+
+      response = node.user.client.subnets.ship(
+        user_id: node.user.id,
+        node_id: node.id,
+        subnet_id: id,
+        payload: payload
+      )
+      if response['subnets']
+        # api v3.1
+        self.class.from_response(node, response['subnets'])
+      else
+        # api v3.1.1
+        self.class.from_response(node, response)
+      end
+    end
+
     # Checks if two Subnet instances have same id (different instances of same record).
     def ==(other)
       other.instance_of?(self.class) && !id.nil? && id == other.id


### PR DESCRIPTION
### ship_card

This changes allows us to call `/v3.1/users/user_id/nodes/node_id/subnets/subnet_id/ship` (`/ship` at the end, different from simple update) with a `PATCH` request as mentioned [here](https://docs.synapsefi.com/reference#native-ship-card).

We are passing the `fee_node_id` which is our `deposit` account ID and the `cardholder_name`.
`expedite` is hard coded as `false` and `card_style_id` is not being sent so Synapse will use our default card style.

### subnet#update

Allows us to update `card subnets` (account_class: `CARD`). This is used for activation/termination of cards.