### PR TITLE
Add ability to specify card style when creating subnet

### DIFF
--- a/lib/synapse_pay_rest/models/subnet/subnet.rb
+++ b/lib/synapse_pay_rest/models/subnet/subnet.rb
@@ -3,7 +3,7 @@ module SynapsePayRest
   # from API calls. This is built on top of the SynapsePayRest::Subnets class and
   # is intended to make it easier to use the API without knowing payload formats
   # or knowledge of REST.
-  # 
+  #
   class Subnet
     # @!attribute [rw] node
     attr_reader :id, :account_num, :account_class, :allowed, :client_id, :client_name, :nickname, :node,
@@ -13,15 +13,15 @@ module SynapsePayRest
     class << self
       # Creates a new subnet in the API belonging to the provided node and
       # returns a subnet instance from the response data.
-      # 
+      #
       # @param nickname [String] any nicknames
       # @param node [SynapsePayRest::BaseNode] node to which the Subnet belongs
       # @see https://docs.synapsepay.com/docs/subnets
       #
       # @raise [SynapsePayRest::Error] if HTTP error or invalid argument format
-      # 
+      #
       # @return [SynapsePayRest::Subnet]
-      # 
+      #
       def create(node:, nickname:, **options)
         raise ArgumentError, 'cannot create a transaction with an UnverifiedNode' if node.is_a?(UnverifiedNode)
         raise ArgumentError, 'node must be a type of BaseNode object' unless node.is_a?(BaseNode)
@@ -42,12 +42,12 @@ module SynapsePayRest
 
       # Queries the API for a subnet belonging to the supplied node by subnet id
       # and returns a Subnet n instance if found.
-      # 
+      #
       # @param node [SynapsePayRest::BaseNode] node to which the subnet belongs
       # @param id [String] id of the subnet to find
-      # 
+      #
       # @raise [SynapsePayRest::Error] if not found or other HTTP error
-      # 
+      #
       # @return [SynapsePayRest::Subnet]
       def find(node:, id:)
         raise ArgumentError, 'node must be a type of BaseNode object' unless node.is_a?(BaseNode)
@@ -63,13 +63,13 @@ module SynapsePayRest
 
       # Queries the API for all subnets belonging to the supplied node and returns
       # them as Subnet instances.
-      # 
+      #
       # @param node [SynapsePayRest::BaseNode] node to which the subnet belongs
       # @param page [String,Integer] (optional) response will default to 1
       # @param per_page [String,Integer] (optional) response will default to 20
-      # 
+      #
       # @raise [SynapsePayRest::Error]
-      # 
+      #
       # @return [Array<SynapsePayRest::Subnet>]
       def all(node:, page: nil, per_page: nil)
         raise ArgumentError, 'node must be a type of BaseNode object' unless node.is_a?(BaseNode)
@@ -89,9 +89,9 @@ module SynapsePayRest
       end
 
       # Creates a Subnet from a response hash.
-      # 
+      #
       # @note Shouldn't need to call this directly.
-      # 
+      #
       def from_response(node, response)
         args = {
           node:               node,
@@ -117,6 +117,7 @@ module SynapsePayRest
           'nickname' => nickname
         }
         payload['account_class'] = options[:account_class] if options[:account_class].present?
+        payload['card_style_id'] = options[:card_style_id] if options[:card_style_id]. present?
         payload
       end
 
@@ -151,11 +152,11 @@ module SynapsePayRest
     end
 
     # Changes Subnet's allowed permission from 'CREDIT' to 'LOCKED'.
-    # 
+    #
     # @param comment [String]
-    # 
+    #
     # @raise [SynapsePayRest::Error]
-    # 
+    #
     # @return [Array<SynapsePayRest::Subnet>] (self)
     def lock
       payload = {'allowed' => 'LOCKED'}
@@ -175,13 +176,13 @@ module SynapsePayRest
     end
 
     # Provisions a card
-    # 
+    #
     # @param fee_node_id [String] Id of the Node to be charged for the fee
     # @param cardholder_name [String] Name of the cardholder
     # @param **options [Hash] Options to pass to Synapse's API
-    # 
+    #
     # @raise [SynapsePayRest::Error]
-    # 
+    #
     # @return [Hash] {
     #   node_id [String]
     #   subnet_id [String]
@@ -225,12 +226,12 @@ module SynapsePayRest
           subnet_id:        response['subnet_id']
         }
       end
-      
+
       args
     end
 
     # Updates the given key value pairs.
-    # 
+    #
     # @param pin [String]
     # @param status [String]
     # @param preferences [Hash]:
@@ -239,9 +240,9 @@ module SynapsePayRest
     #     daily_atm_withdrawal_limit [String, Integer],
     #     daily_transaction_limit [String, Integer]
     #   }
-    # 
+    #
     # @raise [SynapsePayRest::Error] if HTTP error or invalid argument format
-    # 
+    #
     # @return [SynapsePayRest::Subnet] new instance corresponding to same API record
     def update(**options)
       response = node.user.client.subnets.update(


### PR DESCRIPTION
We will have multiple `card_style_id`s to represent the different card art for Alice cards.  This allows us to specify which card art to use when creating the card subnet.