### PR TITLE
Remove card_hash from subnets

### DIFF
--- a/lib/synapse_pay_rest/models/subnet/subnet.rb
+++ b/lib/synapse_pay_rest/models/subnet/subnet.rb
@@ -135,7 +135,6 @@ module SynapsePayRest
 
       def args_for_card_subnet(response)
         {
-          card_hash:          response['card_hash'],
           card_number:        response['card_number'],
           card_style_id:      response['card_style_id'],
           cvc:                response['cvc'],


### PR DESCRIPTION
The current API call returns `nil` for the value of `card_hash` after the creation of a card subnet.  There's no need for us to handle this value.